### PR TITLE
startup: support providing an alt config path.

### DIFF
--- a/ldmudefuns/startup.py
+++ b/ldmudefuns/startup.py
@@ -1,19 +1,18 @@
-def startup():
+def startup(config_path='~/.ldmud-efuns'):
     """ Loads all registered packages that offer the ldmud_efun entry point.
 
-    In the configuration file ~/.ldmud-efuns single efuns can be deactivated
-    with entries like:
+    In the configuration file (default,`~/.ldmud-efuns`) single efuns can be
+    deactivated with entries like:
 
         [efuns]
         name_of_the_efun = off
     """
-
     import pkg_resources, traceback, sys, os, configparser
     import ldmud
 
     config = configparser.ConfigParser()
     config['efuns'] = {}
-    config.read(os.path.expanduser('~/.ldmud-efuns'))
+    config.read(os.path.expanduser(config_path))
     efunconfig = config['efuns']
 
     for entry_point in pkg_resources.iter_entry_points('ldmud_efun'):

--- a/startup.py
+++ b/startup.py
@@ -6,6 +6,9 @@
 #
 #   [efuns]
 #   name_of_the_efun = off
+# 
+# If you would like to load configuration from a different file, pass the
+# path to the startup function, e.g. startup(config_path='~/.ldmud-efuns-test')
 
 from ldmudefuns.startup import startup
 


### PR DESCRIPTION
In some cases users may wish to provide an alternative configuration file to use for ldmud-efuns. This commit adds a new keyword argument to `startup`, `config_path`, that defaults to `~/.ldmud-efuns` but can be overridden with an explicit value by callers.

In my case I have two LDMud processes on the same box and would like to be able to use different configurations (one for testing, and one for production).