### PR TITLE
importlib_metadata 3.6 and Python 3.12 compat fix

### DIFF
--- a/ldmudefuns/help.py
+++ b/ldmudefuns/help.py
@@ -1,5 +1,7 @@
 import ldmud
 
+from .internal import get_config
+
 def format_docstring(efun) -> str:
     doc = getattr(efun, '__doc__', None)
     if doc:
@@ -47,8 +49,6 @@ if hasattr(ldmud, 'registered_efuns'):
             return format_docstring(efun)
 
 else:
-    import os, configparser
-
     try:
         import importlib.metadata as metadata
     except ModuleNotFoundError:
@@ -65,10 +65,7 @@ else:
         SEE ALSO
                 python_reload(E)
         """
-        config = configparser.ConfigParser()
-        config['efuns'] = {}
-        config.read(os.path.expanduser('~/.ldmud-efuns'))
-        efunconfig = config['efuns']
+        efunconfig = get_config()['efuns']
 
         if not efunconfig.getboolean(efunname, True):
             return None

--- a/ldmudefuns/help.py
+++ b/ldmudefuns/help.py
@@ -1,6 +1,6 @@
 import ldmud
 
-from .internal import get_config
+from .internal import get_config, get_entry_points
 
 def format_docstring(efun) -> str:
     doc = getattr(efun, '__doc__', None)
@@ -49,11 +49,6 @@ if hasattr(ldmud, 'registered_efuns'):
             return format_docstring(efun)
 
 else:
-    try:
-        import importlib.metadata as metadata
-    except ModuleNotFoundError:
-        import importlib_metadata as metadata
-
     def python_efun_help(efunname: str) -> str:
         """
         SYNOPSIS
@@ -70,8 +65,7 @@ else:
         if not efunconfig.getboolean(efunname, True):
             return None
 
-        eps = metadata.entry_points()
-        for entry_point in eps.get('ldmud_efun', ()):
+        for entry_point in get_entry_points('ldmud_efun'):
             if entry_point.name != efunname:
                 continue
 

--- a/ldmudefuns/internal.py
+++ b/ldmudefuns/internal.py
@@ -1,5 +1,6 @@
 import os
 import configparser
+import ldmud
 
 def get_config():
     config = configparser.ConfigParser()
@@ -7,3 +8,12 @@ def get_config():
     config['types'] = {}
     config.read(os.path.expanduser('~/.ldmud-efuns'))
     return config
+
+def get_registration_types():
+    ep_types = []
+    config = get_config()
+    if hasattr(ldmud, 'register_type'):
+        ep_types.append(('ldmud_type', 'type', config['types'], ldmud.register_type))
+    if hasattr(ldmud, 'register_efun'):
+        ep_types.append(('ldmud_efun', 'efun', config['efuns'], ldmud.register_efun))
+    return ep_types

--- a/ldmudefuns/internal.py
+++ b/ldmudefuns/internal.py
@@ -1,0 +1,9 @@
+import os
+import configparser
+
+def get_config():
+    config = configparser.ConfigParser()
+    config['efuns'] = {}
+    config['types'] = {}
+    config.read(os.path.expanduser('~/.ldmud-efuns'))
+    return config

--- a/ldmudefuns/internal.py
+++ b/ldmudefuns/internal.py
@@ -24,4 +24,14 @@ def get_registration_types():
     return ep_types
 
 def get_entry_points(group_name):
-    return metadata.entry_points().get(group_name, ())
+    eps = metadata.entry_points()
+
+    # Prior to importlib_metadata 5.0 and Python 3.12 entry_points()
+    # returned a dictionary of entry points keyed to group.
+    if isinstance(eps, dict):
+        return eps.get(group_name, ())
+
+    # For modern versions of importlib_metadata and Python 3.12
+    # entry_points() returns an EntryPoints object that can be
+    # queried with select().
+    return eps.select(group=group_name)

--- a/ldmudefuns/internal.py
+++ b/ldmudefuns/internal.py
@@ -2,6 +2,11 @@ import os
 import configparser
 import ldmud
 
+try:
+    import importlib.metadata as metadata
+except ModuleNotFoundError:
+    import importlib_metadata as metadata
+
 def get_config():
     config = configparser.ConfigParser()
     config['efuns'] = {}
@@ -17,3 +22,6 @@ def get_registration_types():
     if hasattr(ldmud, 'register_efun'):
         ep_types.append(('ldmud_efun', 'efun', config['efuns'], ldmud.register_efun))
     return ep_types
+
+def get_entry_points(group_name):
+    return metadata.entry_points().get(group_name, ())

--- a/ldmudefuns/reload.py
+++ b/ldmudefuns/reload.py
@@ -1,12 +1,7 @@
 import importlib, sys
 import ldmud
 
-try:
-    import importlib.metadata as metadata
-except ModuleNotFoundError:
-    import importlib_metadata as metadata
-
-from .internal import get_registration_types
+from .internal import get_registration_types, get_entry_points, metadata
 
 def reload_modules():
     """
@@ -26,11 +21,10 @@ def reload_modules():
     importlib.reload(metadata)
     modules = dict(sys.modules)
     reloaded = set()
-    eps = metadata.entry_points()
     ep_types = get_registration_types()
 
     for ep_name, ep_desc, ep_config, ep_register in ep_types:
-        for entry_point in eps.get(ep_name,()):
+        for entry_point in get_entry_points(ep_name):
             if ep_config.getboolean(entry_point.name, True):
                 # Remove the corresponding modules from sys.modules
                 # so they will be reloaded.
@@ -49,7 +43,7 @@ def reload_modules():
                     print("Reload module", module)
 
     for ep_name, ep_desc, ep_config, ep_register in ep_types:
-        for entry_point in eps.get(ep_name,()):
+        for entry_point in get_entry_points(ep_name):
             if ep_config.getboolean(entry_point.name, True):
                 try:
                     print("Re-registering Python", ep_desc, entry_point.name)

--- a/ldmudefuns/reload.py
+++ b/ldmudefuns/reload.py
@@ -1,10 +1,12 @@
-import importlib, sys, os, configparser
+import importlib, sys
 import ldmud
 
 try:
     import importlib.metadata as metadata
 except ModuleNotFoundError:
     import importlib_metadata as metadata
+
+from .internal import get_config
 
 def reload_modules():
     """
@@ -26,10 +28,7 @@ def reload_modules():
     reloaded = set()
     eps = metadata.entry_points()
 
-    config = configparser.ConfigParser()
-    config['efuns'] = {}
-    config['types'] = {}
-    config.read(os.path.expanduser('~/.ldmud-efuns'))
+    config = get_config()
 
     ep_types = []
     if hasattr(ldmud, 'register_type'):

--- a/ldmudefuns/reload.py
+++ b/ldmudefuns/reload.py
@@ -6,7 +6,7 @@ try:
 except ModuleNotFoundError:
     import importlib_metadata as metadata
 
-from .internal import get_config
+from .internal import get_registration_types
 
 def reload_modules():
     """
@@ -27,14 +27,7 @@ def reload_modules():
     modules = dict(sys.modules)
     reloaded = set()
     eps = metadata.entry_points()
-
-    config = get_config()
-
-    ep_types = []
-    if hasattr(ldmud, 'register_type'):
-        ep_types.append(('ldmud_type', 'type', config['types'], ldmud.register_type,))
-    if hasattr(ldmud, 'register_efun'):
-        ep_types.append(('ldmud_efun', 'efun', config['efuns'], ldmud.register_efun,))
+    ep_types = get_registration_types()
 
     for ep_name, ep_desc, ep_config, ep_register in ep_types:
         for entry_point in eps.get(ep_name,()):

--- a/ldmudefuns/startup.py
+++ b/ldmudefuns/startup.py
@@ -1,4 +1,4 @@
-from .internal import get_config
+from .internal import get_registration_types
 
 def startup():
     """ Loads all registered packages that offer the ldmud_efun entry point.
@@ -11,24 +11,15 @@ def startup():
     """
 
     import traceback
-    import ldmud
 
     try:
         import importlib.metadata as metadata
     except ModuleNotFoundError:
         import importlib_metadata as metadata
 
-    config = get_config()
-
-    ep_types = []
-    if hasattr(ldmud, 'register_type'):
-        ep_types.append(('ldmud_type', 'type', config['types'], ldmud.register_type,))
-    if hasattr(ldmud, 'register_efun'):
-        ep_types.append(('ldmud_efun', 'efun', config['efuns'], ldmud.register_efun,))
-
     eps = metadata.entry_points()
 
-    for ep_name, ep_desc, ep_config, ep_register in ep_types:
+    for ep_name, ep_desc, ep_config, ep_register in get_registration_types():
         for entry_point in eps.get(ep_name,()):
             if ep_config.getboolean(entry_point.name, True):
                 try:

--- a/ldmudefuns/startup.py
+++ b/ldmudefuns/startup.py
@@ -1,3 +1,5 @@
+from .internal import get_config
+
 def startup():
     """ Loads all registered packages that offer the ldmud_efun entry point.
 
@@ -8,7 +10,7 @@ def startup():
         name_of_the_efun = off
     """
 
-    import traceback, os, configparser
+    import traceback
     import ldmud
 
     try:
@@ -16,10 +18,7 @@ def startup():
     except ModuleNotFoundError:
         import importlib_metadata as metadata
 
-    config = configparser.ConfigParser()
-    config['efuns'] = {}
-    config['types'] = {}
-    config.read(os.path.expanduser('~/.ldmud-efuns'))
+    config = get_config()
 
     ep_types = []
     if hasattr(ldmud, 'register_type'):

--- a/ldmudefuns/startup.py
+++ b/ldmudefuns/startup.py
@@ -1,4 +1,4 @@
-from .internal import get_registration_types
+from .internal import get_registration_types, get_entry_points
 
 def startup():
     """ Loads all registered packages that offer the ldmud_efun entry point.
@@ -12,15 +12,8 @@ def startup():
 
     import traceback
 
-    try:
-        import importlib.metadata as metadata
-    except ModuleNotFoundError:
-        import importlib_metadata as metadata
-
-    eps = metadata.entry_points()
-
     for ep_name, ep_desc, ep_config, ep_register in get_registration_types():
-        for entry_point in eps.get(ep_name,()):
+        for entry_point in get_entry_points(ep_name):
             if ep_config.getboolean(entry_point.name, True):
                 try:
                     print("Registering Python", ep_desc, entry_point.name)

--- a/ldmudefuns/startup.py
+++ b/ldmudefuns/startup.py
@@ -8,7 +8,7 @@ def startup():
         name_of_the_efun = off
     """
 
-    import traceback, sys, os, configparser
+    import traceback, os, configparser
     import ldmud
 
     try:


### PR DESCRIPTION
:wave: After setting up `ldmud-efuns` in a fresh venv w/ Python 3.12+ I noticed the following error at startup and no efuns/types being registered:

```
Traceback (most recent call last):
  File "/home/daniel/Code/C/ldmud/python/startup.py", line 3, in <module>
    startup()
  File "/home/daniel/Code/C/ldmud/.venv/lib/python3.12/site-packages/ldmudefuns/startup.py", line 33, in startup
    for entry_point in eps.get(ep_name,()):
                       ^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
```

The root cause is a breaking change described [in the `importlib.metadata` docs](https://docs.python.org/3/library/importlib.metadata.html#functional-api):

> Changed in version 3.12: The “selectable” entry points were introduced in importlib_metadata 3.6 and Python 3.10. Prior to those changes, entry_points accepted no parameters and always returned a dictionary of entry points, keyed by group. With importlib_metadata 5.0 and Python 3.12, entry_points always returns an EntryPoints object. 

This branch works around that change so the package continues to work with Python 3.12+ and importlib_metadata 5.0+.

I couldn't help but tidy up some duplication commit-by-commit before implementing the fix. If you'd prefer a more minimal diff I'd be happy to rework the branch.